### PR TITLE
docs: Adds a clarification in string.md

### DIFF
--- a/docs/parse/string.md
+++ b/docs/parse/string.md
@@ -5,6 +5,8 @@ title: String
 
 Parse the given string in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format (a space instead of the 'T' is allowed) and return a Day.js object instance.
 
+If the provided string does not adhere to the ISO 8601 format, it will be parsed using the native JavaScript Date object. Depending on the browser, other formats like RFC 2822 might also be accepted.
+
 ```js
 dayjs('2018-04-04T16:00:00.000Z')
 dayjs('2018-04-13 19:18:17.040+02:00')


### PR DESCRIPTION
To clarify the behavior of dayjs when the string containing the date is not in the correct format.