### PR TITLE
Fix calendar method reference which was causing issues with different input types

### DIFF
--- a/docs/plugin/calendar.md
+++ b/docs/plugin/calendar.md
@@ -11,7 +11,7 @@ var calendar = require("dayjs/plugin/calendar");
 
 dayjs.extend(calendar);
 
-dayjs().calendar(dayjs("2008-01-01"));
+dayjs("2008-01-01").calendar();
 dayjs().calendar(null, {
   sameDay: "[Today at] h:mm A", // The same day ( Today at 2:30 AM )
   nextDay: "[Tomorrow at] h:mm A", // The next day ( Tomorrow at 2:30 AM )


### PR DESCRIPTION
This reference to the calendar function causes issues in many cases. If you feed the function an epoch date (ms), it would spit out the calendar date of the current time.

This simple change fixes that issue.

Lmk if i did anything wrong. :)