### PR TITLE
Update Start/End of Time documentation to make 'time' definition more intuitive

### DIFF
--- a/docs/manipulate/end-of.md
+++ b/docs/manipulate/end-of.md
@@ -1,8 +1,8 @@
 ---
 id: end-of
-title: End of Time
+title: End of Unit of Time
 ---
-Returns a cloned Day.js object and set it to the end of a unit of time.
+Returns a cloned Day.js object and set it to the end of a unit of time (ex. month, week, etc.).
 
 ```js
 dayjs().endOf('month')

--- a/docs/manipulate/start-of.md
+++ b/docs/manipulate/start-of.md
@@ -1,9 +1,9 @@
 ---
 id: start-of
-title: Start of Time
+title: Start of Unit of Time
 ---
 
-Returns a cloned Day.js object and set it to the start of a unit of time.
+Returns a cloned Day.js object and set it to the start of a unit of time (ex. month, week, etc.).
 
 ```js
 dayjs().startOf('year')


### PR DESCRIPTION
## Problem
The "Start of Time" and "End of Time" documentation pages are not necessarily immediately intuitive. The term "time" could be misunderstood as referring only to clock time (hours, minutes, seconds), when in fact these methods work with various calendar units like year, month, week, day, etc.

## Solution
- Updated page titles to **"Start of Unit of Time"** and **"End of Unit of Time"** to clarify that "time" refers to calendar/time units
- Added inline examples in the descriptions: "(ex. month, week, etc.)" to immediately show what "unit of time" means
- Maintained the same document IDs (`start-of`, `end-of`) so all existing links continue to work

## Changes
- `docs/manipulate/start-of.md`: Updated title and description
- `docs/manipulate/end-of.md`: Updated title and description

## Benefits
- More intuitive for new users discovering these methods
- Clearer search results once Algolia re-indexes
- Better understanding of what these methods do before reading the full documentation

## Screenshots
**Before:**
<img width="1650" height="947" alt="image" src="https://github.com/user-attachments/assets/cea72860-bcf1-4458-87df-05fc1e6510e5" />

**After:**
<img width="1649" height="942" alt="image" src="https://github.com/user-attachments/assets/cde2c4a1-09c9-4847-bfca-69cefa209ba8" />