### PR TITLE
Fix mismatching format compared to output

### DIFF
--- a/docs/display/calendar-time.md
+++ b/docs/display/calendar-time.md
@@ -32,10 +32,10 @@ To escape characters, wrap them in square brackets (e.g. [Today]).
 ```js
 dayjs().calendar(null, {
   sameDay: '[Today at] h:mm A', // The same day ( Today at 2:30 AM )
-  nextDay: '[Tomorrow]', // The next day ( Tomorrow at 2:30 AM )
-  nextWeek: 'dddd', // The next week ( Sunday at 2:30 AM )
-  lastDay: '[Yesterday]', // The day before ( Yesterday at 2:30 AM )
-  lastWeek: '[Last] dddd', // Last week ( Last Monday at 2:30 AM )
+  nextDay: '[Tomorrow at] h:mm A', // The next day ( Tomorrow at 2:30 AM )
+  nextWeek: 'dddd [at] h:mm A', // The next week ( Sunday at 2:30 AM )
+  lastDay: '[Yesterday at] h:mm A', // The day before ( Yesterday at 2:30 AM )
+  lastWeek: '[Last] dddd [at] h:mm A', // Last week ( Last Monday at 2:30 AM )
   sameElse: 'DD/MM/YYYY' // Everything else ( 7/10/2011 )
 })
 ```


### PR DESCRIPTION
The output shown in the comment behind the value is not matching the format in the value. I updated the format to match the output.